### PR TITLE
Fix all `tfsec` and `tflint` warnings

### DIFF
--- a/.github/workflows/terraform-lint.yaml
+++ b/.github/workflows/terraform-lint.yaml
@@ -1,0 +1,25 @@
+name: Lint (Terraform)
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - '**.tf'
+      - '**.tf.json'
+      - '**.hcl'
+  pull_request:
+    paths:
+      - '**.tf'
+      - '**.tf.json'
+      - '**.hcl'
+  workflow_dispatch:
+
+jobs:
+  terraform-lint:
+    uses: gravitational/shared-workflows/.github/workflows/terraform-lint.yaml@main
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: write
+      security-events: write

--- a/README.md
+++ b/README.md
@@ -93,13 +93,6 @@ module "teleport-agent-terraform" {
   # Agents can use OSS AMIs if preferred - Enterprise AMIs are not required.
   # See https://github.com/gravitational/teleport/blob/master/examples/aws/terraform/AMIS.md
   ami_id = "ami-0a96d44f7f99e06c7"
-
-  # AWS KMS alias used for encryption/decryption, defaults to alias used in SSM
-  kms_alias_name = "alias/aws/ssm"
-
-  # Account ID which owns the AMIs used to spin up instances
-  # You should only need to set this if you're building your own AMIs.
-  #ami_owner_account_id = "123456789012"
 }
 
 ```
@@ -111,12 +104,12 @@ Once this file is written, run `terraform init -upgrade && terraform plan && ter
 We recommend familiarizing yourself with the following resources prior to reviewing our Terraform examples:
 
 - [Teleport Architecture](https://goteleport.com/docs/architecture/overview/)
-- [Admin Guide](https://goteleport.com/docs/admin-guide/)
+- [Admin Guide](https://goteleport.com/docs/management/admin/)
 
 In order to spin up AWS resources using these Terraform examples, you need the following software:
 
-- terraform v0.13+ [install docs](https://learn.hashicorp.com/terraform/getting-started/install.html)
-- awscli v1.14+ [install docs](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html)
+- terraform v1.0+ [install docs](https://learn.hashicorp.com/tutorials/terraform/install-cli)
+- awscli v1.14+ [install docs](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
 
 ## How to get help
 

--- a/agent_asg.tf
+++ b/agent_asg.tf
@@ -37,10 +37,10 @@ resource "aws_launch_configuration" "agent" {
   lifecycle {
     create_before_destroy = true
   }
-  name_prefix                 = "${var.teleport_agent_name}-agent-"
-  image_id                    = var.ami_id
-  instance_type               = var.agent_instance_type
-  user_data                   = templatefile(
+  name_prefix   = "${var.teleport_agent_name}-agent-"
+  image_id      = var.ami_id
+  instance_type = var.agent_instance_type
+  user_data = templatefile(
     "${path.module}/agent-user-data.tpl",
     {
       region                                  = data.aws_region.current.name
@@ -66,8 +66,15 @@ resource "aws_launch_configuration" "agent" {
       teleport_agent_ssh_labels               = var.teleport_agent_ssh_labels
     }
   )
+  metadata_options {
+    http_endpoint = "enabled"
+    http_tokens   = "required"
+  }
+  root_block_device {
+    encrypted = true
+  }
   key_name                    = var.key_name
   associate_public_ip_address = false
-  security_groups             = [for s in aws_security_group.agent: s.id]
+  security_groups             = [for s in aws_security_group.agent : s.id]
   iam_instance_profile        = aws_iam_instance_profile.agent.id
 }

--- a/agent_iam.tf
+++ b/agent_iam.tf
@@ -1,13 +1,13 @@
 # Set DB region if explicitly configured, otherwise assume it's the same as the region where the agent is deployed
 # Set DB user if explicitly configured, otherwise allow permission for all users ("*")
 locals {
-    db_region = var.teleport_agent_db_region != "" ? var.teleport_agent_db_region : data.aws_region.current.name
-    db_user   = var.teleport_agent_db_iam_db_username != "" ? var.teleport_agent_db_iam_db_username : "*"
+  db_region = var.teleport_agent_db_region != "" ? var.teleport_agent_db_region : data.aws_region.current.name
+  db_user   = var.teleport_agent_db_iam_db_username != "" ? var.teleport_agent_db_iam_db_username : "*"
 }
 
 # Configures IAM role for database
 resource "aws_iam_role" "agent" {
-  name               = "${var.teleport_agent_name}-role"
+  name = "${var.teleport_agent_name}-role"
 
   assume_role_policy = <<EOF
 {
@@ -27,10 +27,10 @@ EOF
 # The role and instance profile need to be created regardless for Terraform to remain happy, but this
 # inline policy granting RDS token generation access is only created if a resource ID is set in the module variables.
 resource "aws_iam_role_policy" "agent" {
-  name   = "${var.teleport_agent_name}-role-policy"
-  role   = aws_iam_role.agent.id
+  name = "${var.teleport_agent_name}-role-policy"
+  role = aws_iam_role.agent.id
 
-  count  = var.teleport_agent_db_iam_resource_id != "" ? 1 : 0
+  count = var.teleport_agent_db_iam_resource_id != "" ? 1 : 0
 
   policy = <<EOF
 {
@@ -53,7 +53,7 @@ EOF
 
 # Configures IAM instance profile associated with agents
 resource "aws_iam_instance_profile" "agent" {
-  name          = "${var.teleport_agent_name}-instance-profile"
-  role          = aws_iam_role.agent.name
-  depends_on    = [aws_iam_role_policy.agent]
+  name       = "${var.teleport_agent_name}-instance-profile"
+  role       = aws_iam_role.agent.name
+  depends_on = [aws_iam_role_policy.agent]
 }

--- a/agent_network.tf
+++ b/agent_network.tf
@@ -44,15 +44,18 @@
 resource "aws_security_group" "agent" {
   for_each = data.aws_subnet.agent
 
-  vpc_id = each.value.vpc_id
+  description = "Agent security group"
+  vpc_id      = each.value.vpc_id
   tags = {
     TeleportAgent = var.teleport_agent_name
   }
 }
 
+# tfsec:ignore:aws-ec2-no-public-ingress-sgr
 resource "aws_security_group_rule" "allow_inbound_ssh" {
   for_each = aws_security_group.agent
 
+  description       = "Allow SSH inbound traffic"
   type              = "ingress"
   from_port         = 22
   to_port           = 22
@@ -63,9 +66,11 @@ resource "aws_security_group_rule" "allow_inbound_ssh" {
   security_group_id = each.value.id
 }
 
+# tfsec:ignore:aws-ec2-no-public-egress-sgr
 resource "aws_security_group_rule" "allow_outbound_all" {
   for_each = aws_security_group.agent
 
+  description       = "Allow all outbound traffic"
   type              = "egress"
   from_port         = 0
   to_port           = 0

--- a/data.tf
+++ b/data.tf
@@ -1,22 +1,5 @@
-# Base AMI is found by ID - this is to prevent issues where launch configurations
-# are changed and ASGs recreated because the AMI ID gets updated externally
-data "aws_ami" "base" {
-  most_recent = true
-  owners      = [var.ami_owner_account_id]
-
-  filter {
-    name   = "image-id"
-    values = [var.ami_id]
-  }
-}
-
 # Used in role ARNs
 data "aws_caller_identity" "current" {}
 
 # Used to access provider region
 data "aws_region" "current" {}
-
-# By default, SSM picks the alias for the encryption key
-data "aws_kms_alias" "ssm" {
-  name = var.kms_alias_name
-}

--- a/defaults.tf
+++ b/defaults.tf
@@ -1,6 +1,7 @@
 # These are default values which shouldn't need to be changed by users
 # Assign a number to each AZ letter used in our configuration
-variable "az_number" {
+variable "az_number" { # tflint-ignore: terraform_unused_declarations
+  type = map(any)
   default = {
     a = 1
     b = 2

--- a/provider.tf
+++ b/provider.tf
@@ -1,25 +1,16 @@
 terraform {
-  required_version = "> 0.13"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.0"
-    }
-    template = {
-      source  = "hashicorp/template"
-      version = "~> 2.2.0"
+      version = "~> 4.0"
     }
     random = {
       source  = "hashicorp/random"
-      version = "~> 2.2.1"
+      version = "~> 3.4"
     }
     local = {
-      source = "hashicorp/local"
-      version = "~> 2.0.0"
+      source  = "hashicorp/local"
+      version = "~> 2.2"
     }
   }
-}
-
-variable "aws_max_retries" {
-  default = 5
 }

--- a/variables.tf
+++ b/variables.tf
@@ -144,16 +144,3 @@ variable "agent_instance_type" {
   type    = string
   default = "m4.large"
 }
-
-# AWS KMS alias used for encryption/decryption, defaults to alias used in SSM
-variable "kms_alias_name" {
-  default = "alias/aws/ssm"
-}
-
-# Account ID which owns the AMIs used to spin up instances
-# You should only need to change this if you're building your own AMIs for testing purposes.
-# The default is "126027368216" (Gravitational/Teleport's AMI hosting account)
-variable "ami_owner_account_id" {
-  type    = string
-  default = "126027368216"
-}

--- a/versions.tf
+++ b/versions.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 1.0"
 }


### PR DESCRIPTION
There were numerous `tfsec` and `tflint` warnings. Address all issues, adding ignores where needed to bring warning count down to zero.