### PR TITLE
Add the Trivy misconfiguration scanner

### DIFF
--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -3,7 +3,7 @@ name: Trivy
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -1,0 +1,16 @@
+name: Trivy
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  trivy:
+    uses: gravitational/shared-workflows/.github/workflows/trivy.yaml@main
+    permissions:
+      actions: read
+      contents: read
+      security-events: write


### PR DESCRIPTION
Add the Trivy misconfiguration scanner, which deprecates the tfsec scanner being pulled in via the terraform-lint.yaml shared-workflows file.